### PR TITLE
Global label alias in metrics role

### DIFF
--- a/cartridge/roles/instrumentation/metrics.lua
+++ b/cartridge/roles/instrumentation/metrics.lua
@@ -36,6 +36,8 @@ local function validate_config(conf_new, conf_old)
           format: "prometheus"
       collect:
         default:
+      global_labels:
+        - alias
     ]]
 
     return true
@@ -49,6 +51,17 @@ local function apply_config(conf)
 
     for name, opts in pairs(metrics_conf.collect) do
         collectors[name](opts)
+    end
+
+    if metrics_conf.global_labels then
+        local params = argparse.parse()
+        local labels = {}
+        for _, label_name in ipairs(metrics_conf.global_labels) do
+            if label_name ~= nil then
+                labels[label_name] = params[label_name]
+            end
+        end
+        metrics.set_global_labels(labels)
     end
 
     local httpd = cartridge.service_get("httpd")

--- a/test/integration/metrics_test.lua
+++ b/test/integration/metrics_test.lua
@@ -56,6 +56,9 @@ g.test_role_add_metrics_http_endpoint = function()
             },
             collect = {
               default = {},
+            },
+            global_labels = {
+              'alias'
             }
           }
         }),
@@ -64,4 +67,10 @@ g.test_role_add_metrics_http_endpoint = function()
 
     local resp = server:http_request('get', '/metrics')
     t.assert_equals(resp.status, 200)
+    for _, obs in pairs(resp.json) do
+      t.assert_equals(
+          g.cluster.main_server.alias, obs.label_pairs["alias"],
+          ("Alias label is present in metric %s"):format(obs.metric_name)
+      )
+  end
 end


### PR DESCRIPTION
Allow to use global labels in metrics.

Test for global label 'alias' presented in metrics added. 